### PR TITLE
php 8 support for dependency graphql-php-scalars

### DIFF
--- a/src/WhereConditions/WhereConditionsServiceProvider.php
+++ b/src/WhereConditions/WhereConditionsServiceProvider.php
@@ -64,7 +64,7 @@ class WhereConditionsServiceProvider extends ServiceProvider
                     )
                     ->setTypeDefinition(
                         Parser::scalarTypeDefinition(/** @lang GraphQL */ '
-                            scalar Mixed @scalar(class: "MLL\\\GraphQLScalars\\\Mixed")
+                            scalar Mixed @scalar(class: "MLL\\\GraphQLScalars\\\MixedScalar")
                         ')
                     );
             }


### PR DESCRIPTION


- [ ] Added PHP 8 support for depndent package `mll-lab/graphql-php-scalars`

**Changes**

In PHP 8 Mixed is a reserved word. So the dependent package `mll-lab/graphql-php-scalars` changed their Classname to `MixedScalar` which needed to change in `WhereConditionsServiceProvider.php`
